### PR TITLE
Add show effects preference

### DIFF
--- a/Classes/Preferences/Preferences.h
+++ b/Classes/Preferences/Preferences.h
@@ -50,6 +50,7 @@ typedef enum {
 + (BOOL)disconnectOnDoubleclick;
 + (BOOL)joinOnDoubleclick;
 + (BOOL)leaveOnDoubleclick;
++ (BOOL)showEffects;
 + (BOOL)logTranscript;
 + (MainWindowLayoutType)mainWindowLayout;
 + (BOOL)openBrowserInBackground;

--- a/Classes/Preferences/Preferences.m
+++ b/Classes/Preferences/Preferences.m
@@ -138,6 +138,12 @@ static NSMutableArray* excludeWords;
     return [ud boolForKey:@"Preferences.General.auto_join_on_invited"];
 }
 
++ (BOOL)showEffects
+{
+    NSUserDefaults* ud = [NSUserDefaults standardUserDefaults];
+    return [ud boolForKey:@"Preferences.General.show_effects"];
+}
+
 
 + (TabActionType)tabAction
 {
@@ -826,6 +832,7 @@ static NSMutableArray* excludeWords;
     [d setBool:YES forKey:@"Preferences.General.show_join_leave"];
     [d setBool:YES forKey:@"Preferences.General.show_mode_change"];
     [d setBool:YES forKey:@"Preferences.General.showRename"];
+    [d setBool:YES forKey:@"Preferences.General.show_effects"];
     [d setBool:YES forKey:@"Preferences.General.use_growl"];
     [d setBool:YES forKey:@"Preferences.General.stop_growl_on_active"];
     [d setBool:YES forKey:@"Preferences.General.bounceIconOnEveryPrivateMessage"];

--- a/Classes/Views/Log/LogController.m
+++ b/Classes/Views/Log/LogController.m
@@ -510,6 +510,7 @@
                                 excludeWords:line.excludeWords
                           highlightWholeLine:[Preferences keywordWholeLine]
                               exactWordMatch:[Preferences keywordMatchingMethod] == KEYWORD_MATCH_EXACT
+                                 showEffects:[Preferences showEffects]
                                  highlighted:&key
                                    URLRanges:&urlRanges];
 

--- a/Classes/Views/Log/LogRenderer.h
+++ b/Classes/Views/Log/LogRenderer.h
@@ -11,6 +11,6 @@ NSString* tagEscape(NSString* s);
 @interface LogRenderer : NSObject
 
 + (void)setUp;
-+ (NSString*)renderBody:(NSString*)body keywords:(NSArray*)keywords excludeWords:(NSArray*)excludeWords highlightWholeLine:(BOOL)highlightWholeLine exactWordMatch:(BOOL)exactWordMatch highlighted:(BOOL*)highlighted URLRanges:(NSArray**)urlRanges;
++ (NSString*)renderBody:(NSString*)body keywords:(NSArray*)keywords excludeWords:(NSArray*)excludeWords highlightWholeLine:(BOOL)highlightWholeLine exactWordMatch:(BOOL)exactWordMatch showEffects:(BOOL)showEffects highlighted:(BOOL*)highlighted URLRanges:(NSArray**)urlRanges;
 
 @end

--- a/English.lproj/Preferences.xib
+++ b/English.lproj/Preferences.xib
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16B2327e" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PreferencesController">
@@ -507,8 +507,73 @@
                                                 <binding destination="1247" name="enabled" keyPath="values.Preferences.General.show_inline_images" id="wCk-hu-btv"/>
                                             </connections>
                                         </button>
+                                        <button id="877-Hd-sKk">
+                                            <rect key="frame" x="15" y="175" width="285" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Show effects (bold, underline, italic, colors)" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="NVr-cJ-swm">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <binding destination="1247" name="value" keyPath="values.Preferences.General.show_effects" id="3Wr-7i-krZ"/>
+                                            </connections>
+                                        </button>
+                                        <textField verticalHuggingPriority="750" id="647">
+                                            <rect key="frame" x="15" y="150" width="128" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Message scrollback:" id="4245">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="M9u-2H-dx6">
+                                            <rect key="frame" x="123" y="122" width="21" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="10" id="dcm-xQ-urR">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" id="Pi4-J3-dbf">
+                                            <rect key="frame" x="147" y="116" width="19" height="27"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <stepperCell key="cell" continuous="YES" alignment="left" maxValue="30" doubleValue="10" id="GIZ-z6-gN3"/>
+                                            <connections>
+                                                <action selector="changeNumberOfMessages:" target="-2" id="YbA-Nc-MLY"/>
+                                            </connections>
+                                        </stepper>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="uuR-e1-Y91">
+                                            <rect key="frame" x="15" y="122" width="117" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saved messages:" id="hTl-d0-XGd">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" id="649" customClass="NumericTextField">
+                                            <rect key="frame" x="149" y="147" width="71" height="22"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" id="4246">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                <allowedInputSourceLocales>
+                                                    <string>NSAllRomanInputSourcesLocaleIdentifier</string>
+                                                </allowedInputSourceLocales>
+                                            </textFieldCell>
+                                            <connections>
+                                                <binding destination="-2" name="value" keyPath="maxLogLines" id="4305">
+                                                    <dictionary key="options">
+                                                        <bool key="NSValidatesImmediately" value="YES"/>
+                                                    </dictionary>
+                                                </binding>
+                                            </connections>
+                                        </textField>
                                         <popUpButton verticalHuggingPriority="750" id="108">
-                                            <rect key="frame" x="136" y="122" width="230" height="26"/>
+                                            <rect key="frame" x="135" y="90" width="230" height="26"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <popUpButtonCell key="cell" type="push" title=" " bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="111" id="4242">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -529,7 +594,7 @@
                                             </connections>
                                         </popUpButton>
                                         <button id="118">
-                                            <rect key="frame" x="16" y="127" width="117" height="18"/>
+                                            <rect key="frame" x="15" y="95" width="117" height="18"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <buttonCell key="cell" type="check" title="Log transcripts" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="4244">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -539,60 +604,6 @@
                                                 <binding destination="1247" name="value" keyPath="values.Preferences.General.log_transcript" id="3431"/>
                                             </connections>
                                         </button>
-                                        <textField verticalHuggingPriority="750" id="647">
-                                            <rect key="frame" x="15" y="172" width="131" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Message scrollback:" id="4245">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="649" customClass="NumericTextField">
-                                            <rect key="frame" x="151" y="169" width="71" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" id="4246">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                <allowedInputSourceLocales>
-                                                    <string>NSAllRomanInputSourcesLocaleIdentifier</string>
-                                                </allowedInputSourceLocales>
-                                            </textFieldCell>
-                                            <connections>
-                                                <binding destination="-2" name="value" keyPath="maxLogLines" id="4305">
-                                                    <dictionary key="options">
-                                                        <bool key="NSValidatesImmediately" value="YES"/>
-                                                    </dictionary>
-                                                </binding>
-                                            </connections>
-                                        </textField>\
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="M9u-2H-dx6">
-                                            <rect key="frame" x="123" y="144" width="21" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="10" id="dcm-xQ-urR">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" id="Pi4-J3-dbf">
-                                            <rect key="frame" x="147" y="138" width="19" height="27"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <stepperCell key="cell" continuous="YES" alignment="left" maxValue="30" doubleValue="10" id="GIZ-z6-gN3"/>
-                                            <connections>
-                                                <action selector="changeNumberOfMessages:" target="-2" id="YbA-Nc-MLY"/>
-                                            </connections>
-                                        </stepper>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="uuR-e1-Y91">
-                                            <rect key="frame" x="15" y="144" width="117" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saved messages:" id="hTl-d0-XGd">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
                                     </subviews>
                                 </view>
                             </tabViewItem>
@@ -837,7 +848,7 @@
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="4272" id="101">
-                                                        <rect key="frame" x="0.0" y="0.0" width="403" height="19"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="403" height="178"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -878,7 +889,7 @@
                                                                     <binding destination="4378" name="value" keyPath="arrangedObjects.notification" id="1ZW-Wj-5cS"/>
                                                                 </connections>
                                                             </tableColumn>
-                                                            <tableColumn identifier="sound" editable="NO" width="149.2578125" minWidth="41.2578125" maxWidth="1000" id="4418">
+                                                            <tableColumn identifier="sound" editable="NO" width="148.7578125" minWidth="41.2578125" maxWidth="1000" id="4418">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Sound">
                                                                     <font key="font" metaFont="smallSystem"/>
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -906,7 +917,7 @@
                                                 <rect key="frame" x="1" y="173" width="403" height="15"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
-                                            <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="4270">
+                                            <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="4270">
                                                 <rect key="frame" x="389" y="17" width="15" height="156"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>


### PR DESCRIPTION
Added preference to show textual styling (referred to as "effects"
in the source code), including: bold, italics, underline,
foreground colors, and background colors. When the preference is
disabled users' messages will be stripped of additional formatting.
